### PR TITLE
Add multi-architecture support for amd64 and arm64

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -26,11 +26,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            docker.io/moulick/debug-image
+            ghcr.io/moulick/debug-image
+          tags: |
+            type=ref,event=pr,prefix=pr-,suffix=-{{sha}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
@@ -44,22 +50,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            docker.io/moulick/debug-image
-            ghcr.io/moulick/debug-image
-          tags: |
-            type=ref,event=pr,prefix=pr-,suffix=-{{sha}}
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=ref,event=branch
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -71,6 +72,8 @@ jobs:
           cat >> $GITHUB_STEP_SUMMARY <<EOF
           ## 🐳 Docker Image Published
 
+          Multi-architecture image built for: **linux/amd64**, **linux/arm64**
+
           ### Tags:
           \`\`\`
           ${{ steps.meta.outputs.tags }}
@@ -78,11 +81,11 @@ jobs:
 
           ### Pull command:
           \`\`\`bash
-          docker pull --platform linux/amd64 $(echo '${{ steps.meta.outputs.tags }}' | head -n1)
+          docker pull $(echo '${{ steps.meta.outputs.tags }}' | head -n1)
           \`\`\`
 
           ### Run command:
           \`\`\`bash
-          docker run --rm -it --platform linux/amd64 $(echo '${{ steps.meta.outputs.tags }}' | head -n1)
+          docker run --rm -it $(echo '${{ steps.meta.outputs.tags }}' | head -n1)
           \`\`\`
           EOF

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM docker.io/library/ubuntu:noble
+FROM docker.io/library/ubuntu:noble
 
 LABEL org.opencontainers.image.authors="moulickaggarwal"
 LABEL org.opencontainers.image.source="https://github.com/Moulick/debug-image"
@@ -93,7 +93,8 @@ RUN curl -L "https://get.helm.sh/helm-$HELM_VERSION-linux-$TARGETARCH.tar.gz" \
 
 # https://github.com/fullstorydev/grpcurl/releases
 ENV GRPCURL_VERSION=v1.9.3
-RUN curl -L "https://github.com/fullstorydev/grpcurl/releases/download/${GRPCURL_VERSION}/grpcurl_${GRPCURL_VERSION#v}_linux_${TARGETARCH}.tar.gz" \
+RUN GRPCURL_ARCH=$([ "${TARGETARCH}" = "amd64" ] && echo "x86_64" || echo "${TARGETARCH}") && \
+  curl -L "https://github.com/fullstorydev/grpcurl/releases/download/${GRPCURL_VERSION}/grpcurl_${GRPCURL_VERSION#v}_linux_${GRPCURL_ARCH}.tar.gz" \
   | tar -zxvf - -C /usr/local/bin grpcurl && \
   chmod +x /usr/local/bin/grpcurl && \
   grpcurl --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,9 +78,9 @@ RUN curl -Lo /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/downloa
   chmod +x /usr/local/bin/yq && \
   yq --version
 
-# https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
-ENV KUBECTL_VERSION=1.34.1/2025-09-19
-RUN curl -Lo /usr/local/bin/kubectl "https://s3.us-west-2.amazonaws.com/amazon-eks/$KUBECTL_VERSION/bin/linux/$TARGETARCH/kubectl" && \
+# https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/
+ENV KUBECTL_VERSION=v1.34.1
+RUN curl -Lo /usr/local/bin/kubectl "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/$TARGETARCH/kubectl" && \
   chmod +x /usr/local/bin/kubectl && \
   kubectl version --client=true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,18 @@
-FROM docker.io/ubuntu:noble
-
-ARG TARGETARCH
-
-# https://download.docker.com/linux/static/stable/
-ENV docker_version=28.1.1
-
-# https://github.com/helm/helm/releases
-ENV HELM_VERSION=v3.17.3
-
-# https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
-ENV KUBECTL_VERSION=1.32.0/2025-01-10
-
-# https://github.com/mikefarah/yq/releases/
-ENV YQ_VERSION=v4.45.1
-
-# https://github.com/fullstorydev/grpcurl/releases
-ENV GRPCURL_VERSION=v1.9.1
-
-ENV DEBIAN_FRONTEND="noninteractive"
+FROM --platform=$BUILDPLATFORM docker.io/library/ubuntu:noble
 
 LABEL org.opencontainers.image.authors="moulickaggarwal"
 LABEL org.opencontainers.image.source="https://github.com/Moulick/debug-image"
 LABEL org.opencontainers.image.title="debug-image"
+
+ARG TARGETARCH
+ARG TARGETOS
+ARG TARGETPLATFORM
+
+RUN echo "TARGETARCH: ${TARGETARCH}" && \
+    echo "TARGETOS: ${TARGETOS}" && \
+    echo "TARGETPLATFORM: ${TARGETPLATFORM}"
+
+ENV DEBIAN_FRONTEND="noninteractive"
 
 # Clean up APT when done.
 RUN apt update && \
@@ -42,7 +33,6 @@ RUN apt update && \
   npm \
   rsync \
   python3 \
-  python3-pip \
   zip \
   unzip \
   jq \
@@ -54,38 +44,63 @@ RUN apt update && \
   openssl \
   git \
   parallel \
-  default-jre \
   ssh \
   iptables \
   kafkacat \
   net-tools \
   nmap \
   && \
-  echo "deb [signed-by=/usr/share/keyrings/azlux-archive-keyring.gpg] http://packages.azlux.fr/debian/ stable main" | tee /etc/apt/sources.list.d/azlux.list && \
-  wget -O /usr/share/keyrings/azlux-archive-keyring.gpg https://azlux.fr/repo.gpg && \
-  apt update && \
-  apt install oha -y && \
-  apt clean && rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/* && \
-  DOCKER_ARCH=$([ "$TARGETARCH" = "amd64" ] && echo "x86_64" || echo "aarch64") && \
-  curl -fsSL "https://download.docker.com/linux/static/stable/${DOCKER_ARCH}/docker-${docker_version}.tgz" | tar zxvf - --strip 1 -C /usr/bin docker/docker
+  apt clean && rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
 
-RUN pip3 install --break-system-packages --no-cache-dir --upgrade s3cmd==2.4.0 python-magic
+COPY --from=ghcr.io/astral-sh/uv:0.8 /uv /uvx /bin/
+RUN uv pip install --system --break-system-packages --no-cache-dir --upgrade s3cmd==2.4.0 python-magic
 
-RUN curl -fsSlo awscliv2.zip "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" && \
-  unzip -q awscliv2.zip && ./aws/install && rm -R awscliv2.zip ./aws && aws --version \
-  && \
-  cd /usr/local/bin && \
-  YQ_ARCH=$([ "$TARGETARCH" = "amd64" ] && echo "yq_linux_amd64" || echo "yq_linux_arm64") && \
-  curl -fsSLo yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION%/*}/${YQ_ARCH}" && \
-  curl -fsSLo kubectl "https://s3.us-west-2.amazonaws.com/amazon-eks/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" && \
-  curl -fsSLo helm.tar.gz "https://get.helm.sh/helm-$HELM_VERSION-linux-${TARGETARCH}.tar.gz" && \
-  tar -xzvf helm.tar.gz -C /tmp && mv /tmp/linux-${TARGETARCH}/helm . && rm helm.tar.gz && rm -R /tmp/linux-${TARGETARCH} && \
-  GRPCURL_ARCH=$([ "$TARGETARCH" = "amd64" ] && echo "x86_64" || echo "arm64") && \
-  curl -fsSLo grpcurl.tar.gz "https://github.com/fullstorydev/grpcurl/releases/download/${GRPCURL_VERSION}/grpcurl_${GRPCURL_VERSION#v}_linux_${GRPCURL_ARCH}.tar.gz" && \
-  tar -xzvf grpcurl.tar.gz && rm grpcurl.tar.gz && \
-  chmod +x yq && yq --version && \
-  chmod +x kubectl && kubectl version --client=true && \
-  chmod +x helm && helm version && \
-  chmod +x grpcurl && grpcurl --version && \
-  curl -fsSL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash && \
+# https://download.docker.com/linux/static/stable/
+ENV docker_version=28.5.0
+RUN curl -L "https://download.docker.com/linux/static/stable/$(uname -m)/docker-${docker_version}.tgz" \
+  | tar -zxvf - --strip 1 -C /usr/bin docker/docker
+
+RUN curl -lo awscliv2.zip "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" && \
+  unzip -q awscliv2.zip && \
+  ./aws/install && \
+  rm -R awscliv2.zip ./aws && \
+  aws --version
+
+# https://github.com/hatoo/oha/releases
+ENV OHA_VERSION=v1.10.0
+RUN curl -Lo /usr/local/bin/oha "https://github.com/hatoo/oha/releases/download/${OHA_VERSION}/oha-linux-${TARGETARCH}" && \
+  chmod +x /usr/local/bin/oha && \
+  oha --version
+
+# https://github.com/mikefarah/yq/releases/
+ENV YQ_VERSION=v4.47.2
+RUN curl -Lo /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_$TARGETARCH" && \
+  chmod +x /usr/local/bin/yq && \
+  yq --version
+
+# https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
+ENV KUBECTL_VERSION=1.34.1/2025-09-19
+RUN curl -Lo /usr/local/bin/kubectl "https://s3.us-west-2.amazonaws.com/amazon-eks/$KUBECTL_VERSION/bin/linux/$TARGETARCH/kubectl" && \
+  chmod +x /usr/local/bin/kubectl && \
+  kubectl version --client=true
+
+# https://github.com/helm/helm/releases
+ENV HELM_VERSION=v3.19.0
+RUN curl -L "https://get.helm.sh/helm-$HELM_VERSION-linux-$TARGETARCH.tar.gz" \
+  | tar -zxvf - --strip-components=1 -C /usr/local/bin linux-$TARGETARCH/helm && \
+  chmod +x /usr/local/bin/helm && \
+  helm version
+
+# https://github.com/fullstorydev/grpcurl/releases
+ENV GRPCURL_VERSION=v1.9.3
+RUN curl -L "https://github.com/fullstorydev/grpcurl/releases/download/${GRPCURL_VERSION}/grpcurl_${GRPCURL_VERSION#v}_linux_${TARGETARCH}.tar.gz" \
+  | tar -zxvf - -C /usr/local/bin grpcurl && \
+  chmod +x /usr/local/bin/grpcurl && \
+  grpcurl --version
+
+# https://github.com/kubernetes-sigs/kustomize/releases
+ENV KUSTOMIZE_VERSION=v5.7.1
+RUN curl -L "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_${TARGETARCH}.tar.gz" \
+  | tar -zxvf - -C /usr/local/bin kustomize && \
+  chmod +x /usr/local/bin/kustomize && \
   kustomize version


### PR DESCRIPTION
- Remove hardcoded amd64 base image
- Add TARGETARCH build argument for platform detection
- Update Docker binary download to support x86_64 and aarch64
- Update yq, kubectl, helm, and grpcurl downloads for both architectures
- Enable building for linux/amd64 and linux/arm64 platforms
